### PR TITLE
Change include-targets to a variadic option

### DIFF
--- a/Sources/xccov2lcov/main.swift
+++ b/Sources/xccov2lcov/main.swift
@@ -17,7 +17,7 @@ struct CmdError: Error, CustomStringConvertible {
 command(
     Argument<String>("inputFilename", description: "Input filename (output of `xccov view --report --json file.xcresult`)"),
     Option("trim-path", default: "", description: "Path to trim from start of paths in input file"),
-    Option<[String]>("include-targets", default: [], description: "Targets to include in output (default: all targets)"),
+    VariadicOption<String>("include-targets", default: "", description: "Targets to include in output (default: all targets)"),
     Option<String>("mode", default: "simple", description: "Output mode: 'simple' includes only DA records, 'full' includes 'FN*' records")
 ) {
     inputFilename, trimPath, includeTargets, mode in

--- a/Sources/xccov2lcov/main.swift
+++ b/Sources/xccov2lcov/main.swift
@@ -17,7 +17,7 @@ struct CmdError: Error, CustomStringConvertible {
 command(
     Argument<String>("inputFilename", description: "Input filename (output of `xccov view --report --json file.xcresult`)"),
     Option("trim-path", default: "", description: "Path to trim from start of paths in input file"),
-    VariadicOption<String>("include-targets", default: "", description: "Targets to include in output (default: all targets)"),
+    VariadicOption<String>("include-targets", default: [], description: "Targets to include in output (default: all targets)"),
     Option<String>("mode", default: "simple", description: "Output mode: 'simple' includes only DA records, 'full' includes 'FN*' records")
 ) {
     inputFilename, trimPath, includeTargets, mode in


### PR DESCRIPTION
This change will allow the `--include-targets` option to be variadic. So now multiple targets can be included as follows.

```
swift run xccov2lcov cov.json > lcov.info --include-targets Target1.app --include-targets Target2.app
```

The reason for this change is because I was unable to successfully add multiple targets with the current definition of `Option<[String]>`.